### PR TITLE
SMMSensors - System Management Mode Sensors Plugin

### DIFF
--- a/HWSensors.xcodeproj/project.pbxproj
+++ b/HWSensors.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		7EBEB1DB17B1754D00C114B5 /* GPUSensors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7EBEB1D917B1754D00C114B5 /* GPUSensors.cpp */; };
 		7ECCB63E18537A7000D95FB4 /* cik.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7ECCB63D18537A7000D95FB4 /* cik.cpp */; };
 		7EDFC7581E05A9F3005A6F96 /* gp100.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7EDFC7561E05A9F3005A6F96 /* gp100.cpp */; };
+		D452B91921075817008456D6 /* SMMSensors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D452B91821075817008456D6 /* SMMSensors.cpp */; };
 		F6D276032023D87B00D392E1 /* vega.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6D276022023D87B00D392E1 /* vega.cpp */; };
 /* End PBXBuildFile section */
 
@@ -231,6 +232,12 @@
 		7EFF9518182AD44700C637C8 /* FakeSMCKeyStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FakeSMCKeyStore.h; path = FakeSMCKeyStore/FakeSMCKeyStore.h; sourceTree = SOURCE_ROOT; };
 		7EFF9519182AD44700C637C8 /* FakeSMCKeyStoreUserClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FakeSMCKeyStoreUserClient.cpp; path = FakeSMCKeyStore/FakeSMCKeyStoreUserClient.cpp; sourceTree = SOURCE_ROOT; };
 		7EFF951A182AD44700C637C8 /* FakeSMCKeyStoreUserClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FakeSMCKeyStoreUserClient.h; path = FakeSMCKeyStore/FakeSMCKeyStoreUserClient.h; sourceTree = SOURCE_ROOT; };
+		D424E591210829DF00ACCF15 /* smm.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = smm.h; sourceTree = "<group>"; };
+		D452B91621075817008456D6 /* SMMSensors.kext */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SMMSensors.kext; sourceTree = BUILT_PRODUCTS_DIR; };
+		D452B91821075817008456D6 /* SMMSensors.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SMMSensors.cpp; sourceTree = "<group>"; };
+		D452B91F21075882008456D6 /* SMMSensors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SMMSensors.h; sourceTree = "<group>"; };
+		D452B92121075CEA008456D6 /* SMMSensors-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "SMMSensors-Info.plist"; sourceTree = "<group>"; };
+		D49D43552107728A00CDC565 /* SMMSensors-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SMMSensors-Prefix.pch"; sourceTree = "<group>"; };
 		F6D276012023D76700D392E1 /* vega.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = vega.h; sourceTree = "<group>"; };
 		F6D276022023D87B00D392E1 /* vega.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = vega.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -271,6 +278,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D452B91221075817008456D6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -284,6 +298,7 @@
 				7E79B81B15BA99350079AAE8 /* CPUSensors */,
 				7EADE20815E5602F00FD117C /* GPUSensors */,
 				6A4E473A152178A00038C5DE /* LPCSensors */,
+				D452B91721075817008456D6 /* SMMSensors */,
 				1D05ABE613ED0DAD00EADBF6 /* Frameworks */,
 				1D05ABE513ED0DAD00EADBF6 /* Products */,
 			);
@@ -297,6 +312,7 @@
 				6A4E4739152178A00038C5DE /* LPCSensors.kext */,
 				7E79B81A15BA99350079AAE8 /* CPUSensors.kext */,
 				7EADE20715E5602E00FD117C /* GPUSensors.kext */,
+				D452B91621075817008456D6 /* SMMSensors.kext */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -722,6 +738,26 @@
 			name = Kernel;
 			sourceTree = "<group>";
 		};
+		D452B91721075817008456D6 /* SMMSensors */ = {
+			isa = PBXGroup;
+			children = (
+				D424E591210829DF00ACCF15 /* smm.h */,
+				D452B91821075817008456D6 /* SMMSensors.cpp */,
+				D452B91F21075882008456D6 /* SMMSensors.h */,
+				D452B91E21075847008456D6 /* Supporting Files */,
+			);
+			path = SMMSensors;
+			sourceTree = "<group>";
+		};
+		D452B91E21075847008456D6 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				D452B92121075CEA008456D6 /* SMMSensors-Info.plist */,
+				D49D43552107728A00CDC565 /* SMMSensors-Prefix.pch */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -810,6 +846,23 @@
 			productReference = 7EADE20715E5602E00FD117C /* GPUSensors.kext */;
 			productType = "com.apple.product-type.kernel-extension";
 		};
+		D452B91521075817008456D6 /* SMMSensors */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D452B91B21075817008456D6 /* Build configuration list for PBXNativeTarget "SMMSensors" */;
+			buildPhases = (
+				D452B91121075817008456D6 /* Sources */,
+				D452B91221075817008456D6 /* Frameworks */,
+				D452B91421075817008456D6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SMMSensors;
+			productName = SMMSensors;
+			productReference = D452B91621075817008456D6 /* SMMSensors.kext */;
+			productType = "com.apple.product-type.kernel-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -840,6 +893,7 @@
 				7E79B81915BA99350079AAE8 /* CPUSensors */,
 				7EADE20615E5602E00FD117C /* GPUSensors */,
 				6A4E4738152178A00038C5DE /* LPCSensors */,
+				D452B91521075817008456D6 /* SMMSensors */,
 			);
 		};
 /* End PBXProject section */
@@ -874,6 +928,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		7EADE20415E5602E00FD117C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D452B91421075817008456D6 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -979,6 +1040,14 @@
 				7E17E171169C532100E40FC7 /* si.cpp in Sources */,
 				7E148DDA16F7B5E800A3F28E /* nv84.cpp in Sources */,
 				7EBEB1DB17B1754D00C114B5 /* GPUSensors.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D452B91121075817008456D6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D452B91921075817008456D6 /* SMMSensors.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1297,6 +1366,52 @@
 			};
 			name = Release;
 		};
+		D452B91C21075817008456D6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "SMMSensors/SMMSensors-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "SMMSensors/SMMSensors-Info.plist";
+				INSTALL_PATH = "$(SYSTEM_LIBRARY_DIR)/Extensions/FakeSMC.kext/Contents/PlugIns";
+				MODULE_NAME = org.hwsensors.SMMSensors;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGET_DIR = SMMSensors;
+				WRAPPER_EXTENSION = kext;
+			};
+			name = Debug;
+		};
+		D452B91D21075817008456D6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "SMMSensors/SMMSensors-Prefix.pch";
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "SMMSensors/SMMSensors-Info.plist";
+				INFOPLIST_PREFIX_HEADER = Shared/HWSensorsVersion.pch;
+				INFOPLIST_PREPROCESS = YES;
+				INSTALL_PATH = "$(SYSTEM_LIBRARY_DIR)/Extensions/FakeSMC.kext/Contents/PlugIns";
+				MODULE_NAME = org.hwsensors.SMMSensors;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGET_DIR = SMMSensors;
+				WRAPPER_EXTENSION = kext;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1350,6 +1465,15 @@
 			buildConfigurations = (
 				7EADE21215E5602F00FD117C /* Debug */,
 				7EADE21315E5602F00FD117C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D452B91B21075817008456D6 /* Build configuration list for PBXNativeTarget "SMMSensors" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D452B91C21075817008456D6 /* Debug */,
+				D452B91D21075817008456D6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/SMMSensors/SMMSensors-Info.plist
+++ b/SMMSensors/SMMSensors-Info.plist
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Source Code</key>
+	<string>SOURCE_CODE_LINK</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>SMMSENSORS_BUNDLE</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>KEXT</string>
+	<key>CFBundleShortVersionString</key>
+	<string>HWSENSORS_VERSION</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>HWSENSORS_REVISION</string>
+	<key>IOKitPersonalities</key>
+	<dict>
+		<key>SMM Monitoring Plugin</key>
+		<dict>
+			<key>IOMatchCategory</key>
+			<string>FakeSMCPlugin</string>
+			<key>IOClass</key>
+			<string>SMMSensors</string>
+			<key>IOProviderClass</key>
+			<string>IOPlatformDevice</string>
+			<key>Platform Profile</key>
+			<dict>
+				<key>Dell</key>
+				<dict>
+					<key>02PG84</key>
+					<dict>
+						<key>Description</key>
+						<string>Dell XPS 9360 (i7-8550U)</string>
+						<key>Tachometers</key>
+						<dict>
+							<key>System Fan</key>
+							<dict>
+								<key>Disabled</key>
+								<false/>
+								<key>Index</key>
+								<integer>0</integer>
+							</dict>
+						</dict>
+						<key>Temperatures</key>
+						<dict>
+							<key>CPU Package</key>
+							<dict>
+								<key>Disabled</key>
+								<true/>
+								<key>Index</key>
+								<integer>0</integer>
+							</dict>
+							<key>Ambient</key>
+							<dict>
+								<key>Disabled</key>
+								<true/>
+								<key>Index</key>
+								<integer>1</integer>
+							</dict>
+							<key>Thermal Zone</key>
+							<dict>
+								<key>Disabled</key>
+								<true/>
+								<key>Index</key>
+								<integer>2</integer>
+							</dict>
+							<key>Mainboard</key>
+							<dict>
+								<key>Disabled</key>
+								<true/>
+								<key>Index</key>
+								<integer>3</integer>
+							</dict>
+							<key>Memory Module</key>
+							<dict>
+								<key>Disabled</key>
+								<true/>
+								<key>Index</key>
+								<integer>4</integer>
+							</dict>
+						</dict>
+					</dict>
+				</dict>
+				<key>Default</key>
+				<dict>
+					<key>DisableDevice</key>
+					<false/>
+					<key>FanMultiplier</key>
+					<integer>1</integer>
+					<key>ForceLoad</key>
+					<false/>
+					<key>Tachometers</key>
+					<dict>
+						<key>System Fan</key>
+						<dict>
+							<key>Disabled</key>
+							<false/>
+							<key>Index</key>
+							<integer>0</integer>
+						</dict>
+					</dict>
+					<key>Temperatures</key>
+					<dict>
+						<key>CPU Package</key>
+						<dict>
+							<key>Disabled</key>
+							<true/>
+							<key>Index</key>
+							<integer>0</integer>
+						</dict>
+					</dict>
+				</dict>
+			</dict>
+			<key>IONameMatch</key>
+			<string>bios</string>
+		</dict>
+	</dict>
+	<key>NSHumanReadableCopyright</key>
+	<string>MIT License</string>
+	<key>OSBundleLibraries</key>
+	<dict>
+		<key>FAKESMCKEYSTORE_BUNDLE</key>
+		<string>FAKESMCKEYSTORE_COMPATIBLE</string>
+		<key>com.apple.kpi.iokit</key>
+		<string>10.6</string>
+		<key>com.apple.kpi.libkern</key>
+		<string>10.6</string>
+		<key>com.apple.kpi.mach</key>
+		<string>10.6</string>
+		<key>com.apple.kpi.unsupported</key>
+		<string>10.6</string>
+	</dict>
+</dict>
+</plist>

--- a/SMMSensors/SMMSensors-Prefix.pch
+++ b/SMMSensors/SMMSensors-Prefix.pch
@@ -1,0 +1,3 @@
+//
+// Prefix header for all source files of the 'SMMSensors' target in the 'SMMSensors' project
+//

--- a/SMMSensors/SMMSensors.cpp
+++ b/SMMSensors/SMMSensors.cpp
@@ -1,0 +1,408 @@
+//
+//  SMMSensors.cpp
+//  HWSensors
+//
+//  Created by darkvoid on 25.07.18.
+//
+//  Based on Linux dell-smm-hwmon (https://github.com/torvalds/linux/blob/master/drivers/hwmon/dell-smm-hwmon.c)
+//
+//  The MIT License (MIT)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+//  and associated documentation files (the "Software"), to deal in the Software without restriction,
+//  including without limitation the rights to use, copy, modify, merge, publish, distribute,
+//  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all copies or
+//  substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+//  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include "SMMSensors.h"
+#include "smm.h"
+
+#include <IOKit/IODeviceTreeSupport.h>
+#include <IOKit/IORegistryEntry.h>
+
+//REVIEW: avoids problem with Xcode 5.1.0 where -dead_strip eliminates these required symbols
+#include <libkern/OSKextLib.h>
+void* _org_rehabman_dontstrip[] =
+{
+    (void*)&OSKextGetCurrentIdentifier,
+    (void*)&OSKextGetCurrentLoadTag,
+    (void*)&OSKextGetCurrentVersionString,
+};
+
+#define super FakeSMCPlugin
+OSDefineMetaClassAndStructors(SMMSensors, FakeSMCPlugin)
+
+/*
+ * Call the System Management Mode BIOS. Code provided by Jonathan Buzzard.
+ */
+static int smm_cmd(struct smm_regs* regs)
+{
+    int rc;
+    unsigned int eax = regs->eax;
+
+    asm volatile("pushq %%rax\n\t"
+                 "movl 0(%%rax),%%edx\n\t"
+                 "pushq %%rdx\n\t"
+                 "movl 4(%%rax),%%ebx\n\t"
+                 "movl 8(%%rax),%%ecx\n\t"
+                 "movl 12(%%rax),%%edx\n\t"
+                 "movl 16(%%rax),%%esi\n\t"
+                 "movl 20(%%rax),%%edi\n\t"
+                 "popq %%rax\n\t"
+                 "out %%al,$0xb2\n\t"
+                 "out %%al,$0x84\n\t"
+                 "xchgq %%rax,(%%rsp)\n\t"
+                 "movl %%ebx,4(%%rax)\n\t"
+                 "movl %%ecx,8(%%rax)\n\t"
+                 "movl %%edx,12(%%rax)\n\t"
+                 "movl %%esi,16(%%rax)\n\t"
+                 "movl %%edi,20(%%rax)\n\t"
+                 "popq %%rdx\n\t"
+                 "movl %%edx,0(%%rax)\n\t"
+                 "pushfq\n\t"
+                 "popq %%rax\n\t"
+                 "andl $1,%%eax\n"
+                 : "=a"(rc)
+                 :    "a"(regs)
+                 :    "%ebx", "%ecx", "%edx", "%esi", "%edi", "memory");
+    
+    if (rc != 0 || (regs->eax & 0xffff) == 0xffff || regs->eax == eax)
+        rc = -1;
+
+    return rc;
+}
+
+// Read fan status
+int SMMSensors::getFanStatus(int fan)
+{
+    struct smm_regs regs = { .eax = kSMM_GET_FAN, };
+    
+    regs.ebx = fan & 0xff;
+    
+    return smm_cmd(&regs) ? : regs.eax & 0xff;
+}
+
+// Read the fan speed in RPM.
+int SMMSensors::getFanSpeed(int fan)
+{
+    struct smm_regs regs = { .eax = kSMM_GET_SPEED, };
+    
+    regs.ebx = fan & 0xff;
+    return smm_cmd(&regs) ? : (regs.eax & 0xffff) * fanMultiplier;
+}
+
+// Read fan type
+int SMMSensors::getFanType(int fan)
+{
+    /* kSMM_GET_FAN_TYPE SMM call is expensive, so cache values */
+    if (fanTypes[fan] == INT_MIN) {
+        struct smm_regs regs = { .eax = kSMM_GET_FAN_TYPE, };
+        
+        regs.ebx = fan & 0xff;
+        
+        fanTypes[fan] = smm_cmd(&regs) ? : regs.eax & 0xff;
+    }
+
+    return fanTypes[fan];
+}
+
+// Read the fan nominal rpm for specific fan speed.
+int SMMSensors::getFanNominalSpeed(int fan, int speed)
+{
+    struct smm_regs regs = { .eax = kSMM_GET_NOM_SPEED, };
+
+    regs.ebx = (fan & 0xff) | (speed << 8);
+    return smm_cmd(&regs) ? : (regs.eax & 0xffff) * fanMultiplier;
+}
+
+// Set the fan speed (off, low, high). Returns the new fan status.
+int SMMSensors::setFan(int fan, int speed)
+{
+    struct smm_regs regs = { .eax = kSMM_SET_FAN, };
+    
+    speed = (speed < 0) ? 0 : speed;
+    regs.ebx = (fan & 0xff) | (speed << 8);
+    
+    return smm_cmd(&regs) ? : getFanStatus(fan);
+}
+
+int SMMSensors::getTempType(int sensor)
+{
+    struct smm_regs regs = { .eax = kSMM_GET_TEMP_TYPE, };
+    
+    regs.ebx = sensor & 0xff;
+    return smm_cmd(&regs) ? : regs.eax & 0xff;
+}
+
+// Read temperature (internal)
+int SMMSensors::_getTemp(int sensor)
+{
+    struct smm_regs regs = {
+        .eax = kSMM_GET_TEMP,
+        .ebx = sensor & 0xff,
+    };
+
+    return smm_cmd(&regs) ? : regs.eax & 0xff;
+}
+
+int SMMSensors::getTemp(int sensor)
+{
+    int temp = _getTemp(sensor);
+    
+    /*
+     * Sometimes the temperature sensor returns 0x99, which is out of range.
+     * In this case we retry (once) before returning an error.
+     # 1003655137 00000058 00005a4b
+     # 1003655138 00000099 00003a80 <--- 0x99 = 153 degrees
+     # 1003655139 00000054 00005c52
+     */
+    if (temp == 0x99) {
+        IOSleep(100);
+        temp = _getTemp(sensor);
+    }
+    /*
+     * Return 0 for all invalid temperatures.
+     *
+     * Known instances are the 0x99 value as seen above as well as
+     * 0xc1 (193), which may be returned when trying to read the GPU
+     * temperature if the system supports a GPU and it is currently
+     * turned off.
+     */
+    if (temp > SMM_MAX_TEMP)
+        return 0;
+    
+    return temp;
+}
+
+// Read the power status.
+int SMMSensors::getPowerStatus(void)
+{
+    struct smm_regs regs = { .eax = kSMM_GET_POWER_STATUS, };
+    int rc;
+    
+    rc = smm_cmd(&regs);
+    if (rc < 0)
+        return rc;
+    
+    return (regs.eax & 0xff) == kSMM_POWER_AC ? kSMM_POWER_AC : kSMM_POWER_BATTERY;
+}
+
+bool SMMSensors::getDellSignature()
+{
+    struct smm_regs regs = { .eax = kSMM_GET_DELL_SIG, };
+    int rc;
+
+    rc = smm_cmd(&regs);
+    if (rc < 0)
+        return false;
+
+    return (regs.eax == SMM_DELL_SIG_2 && regs.edx == SMM_DELL_SIG_1);
+}
+
+const char * SMMSensors::getFanTypeName(int fanType)
+{
+    switch (fanType)
+    {
+        case kSMM_FAN_PROCESSOR:
+            return "CPU fan";
+        case kSMM_FAN_MOTHERBOARD:
+            return "Motherboard fan";
+        case kSMM_FAN_GPU:
+            return "GPU fan";
+        case kSMM_FAN_PSU:
+            return "PSU fan";
+        case kSMM_FAN_CHIPSET:
+            return "Chipset fan";
+        default:
+            return "Misc. fan";
+    }
+}
+
+const char * SMMSensors::getTempTypeName(int sensorType)
+{
+    switch (sensorType)
+    {
+        case kSMM_TEMP_CPU:
+            return "CPU temperature";
+        case kSMM_TEMP_GPU:
+            return "GPU temperature";
+        case kSMM_TEMP_MEMORY:
+            return "Memory temperature";
+        case kSMM_TEMP_MISC:
+            return "Misc. temperature";
+        case kSMM_TEMP_AMBIENT:
+            return "Ambient temperature";
+        default:
+            return "Other temperature";
+    }
+}
+
+bool SMMSensors::willReadSensorValue(FakeSMCSensor *sensor, float *outValue)
+{
+    switch (sensor->getGroup()) {
+        case kFakeSMCTemperatureSensor:
+            *outValue = getTemp(sensor->getIndex());
+            break;
+        case kFakeSMCTachometerSensor:
+            *outValue = getFanSpeed(sensor->getIndex());
+            break;
+        default:
+            return false;
+    }
+                                    
+    return true;
+}
+
+bool SMMSensors::start(IOService *provider)
+{
+    if (!super::start(provider))
+        return false;
+    
+    fanMultiplier = 1;
+    
+    int registered_sensors = 0;
+    
+    // Configure
+    if (OSDictionary *configuration = getConfigurationNode())
+    {
+        OSBoolean* disable = OSDynamicCast(OSBoolean, configuration->getObject("DisableDevice"));
+        if (disable && disable->isTrue()) {
+            return false;
+        }
+        
+        OSBoolean* ignoreSignature = OSDynamicCast(OSBoolean, configuration->getObject("ForceLoad"));
+
+        // Validate Dell SMM signature
+        if (!ignoreSignature || ignoreSignature->isFalse()) {
+            if (!getDellSignature()) {
+                HWSensorsErrorLog("Unable to validate Dell SMM signature, not loading SMMSensors\n");
+                return false;
+            }
+        }
+
+        OSNumber* numberFanMultiplier = OSDynamicCast(OSNumber, configuration->getObject("FanMultiplier"));
+        if (numberFanMultiplier) {
+            fanMultiplier = numberFanMultiplier->unsigned32BitValue();
+            HWSensorsInfoLog("Tachometer fan multiplier \"%d\"", fanMultiplier);
+        }
+
+        /* Add platform configured fans */
+        OSDictionary* tachometers = OSDynamicCast(OSDictionary, configuration->getObject("Tachometers"));
+
+        if (tachometers) {
+            OSCollectionIterator *iterator = OSCollectionIterator::withCollection(tachometers);
+            
+            while (OSString *key = OSDynamicCast(OSString, iterator->getNextObject())) {
+                
+                OSDictionary *tachometer = OSDynamicCast(OSDictionary, tachometers->getObject(key));
+
+                if (tachometer) {
+                    // Skip over disabled items
+                    OSBoolean* disabled = OSDynamicCast(OSBoolean, tachometer->getObject("Disabled"));
+
+                    if (disabled && disabled->isTrue())
+                        continue;
+
+                    OSNumber* tachometerIndex = OSDynamicCast(OSNumber, tachometer->getObject("Index"));
+
+                    if (!tachometerIndex) {
+                        HWSensorsErrorLog("No SMM index configured for tachometer sensor \"%s\".", key->getCStringNoCopy());
+                        continue;
+                    }
+
+                    int fanType = getFanType(tachometerIndex->unsigned32BitValue());
+                    
+                    if (fanType != -1) {
+                        FakeSMCSensor * sensor = addTachometer(tachometerIndex->unsigned32BitValue(), key->getCStringNoCopy(), FAN_RPM);
+
+                        if (sensor != NULL) {
+                            registered_sensors++;
+                            HWSensorsInfoLog("Registered tachometer sensor \"%s\" for SMM fan index \"%d\", type \"%s\".", key->getCStringNoCopy(), tachometerIndex->unsigned32BitValue(), getFanTypeName(fanType));
+                            
+                            this->keyStore->updateFanCounterKey();
+                            UInt8* fanCount = (UInt8 *)this->keyStore->getKey(KEY_FAN_NUMBER)->getValue();
+                            
+                            HWSensorsInfoLog("Fancount: %d", *fanCount);
+                        } else {
+                            HWSensorsInfoLog("Failed to register tachometer sensor \"%s\" for SMM fan index \"%d\"", key->getCStringNoCopy(), tachometerIndex->unsigned32BitValue());
+                        }
+                    } else {
+                        HWSensorsErrorLog("Failed to validate sensor \"%s\" for SMM fan index \"%d\"", key->getCStringNoCopy(), tachometerIndex->unsigned32BitValue());
+                    }
+                }
+            }
+        }
+        
+        /* Add platform configured temperature sensors */
+        OSDictionary* temperatures = OSDynamicCast(OSDictionary, configuration->getObject("Temperatures"));
+        
+        if (temperatures) {
+            OSCollectionIterator *iterator = OSCollectionIterator::withCollection(temperatures);
+            
+            while (OSString *key = OSDynamicCast(OSString, iterator->getNextObject())) {
+                
+                OSDictionary *temperature = OSDynamicCast(OSDictionary, temperatures->getObject(key));
+                
+                if (temperature) {
+                    // Skip over disabled items
+                    OSBoolean* disabled = OSDynamicCast(OSBoolean, temperature->getObject("Disabled"));
+                    
+                    if (disabled && disabled->isTrue())
+                        continue;
+                    
+                    OSNumber* temperatureIndex = OSDynamicCast(OSNumber, temperature->getObject("Index"));
+                    
+                    if (!temperatureIndex) {
+                        HWSensorsErrorLog("No SMM index configured for temperature sensor \"%s\".", key->getCStringNoCopy());
+                        continue;
+                    }
+
+                    int tempType = getTempType(temperatureIndex->unsigned32BitValue());
+                    
+                    if (tempType != -1) {
+
+                        FakeSMCSensor* sensor = addSensorUsingAbbreviation(key->getCStringNoCopy(), kFakeSMCCategoryTemperature, kFakeSMCTemperatureSensor, temperatureIndex->unsigned32BitValue());
+                        
+                        if (sensor != NULL) {
+                            registered_sensors++;
+                            HWSensorsInfoLog("Registered temperature sensor \"%s\" for SMM temperature sensor index \"%d\", type \"%s\".", key->getCStringNoCopy(), temperatureIndex->unsigned32BitValue(), getTempTypeName(tempType));
+                        } else {
+                            HWSensorsInfoLog("Failed to register tachometer sensor \"%s\" for SMM temperature sensor index \"%d\"", key->getCStringNoCopy(), temperatureIndex->unsigned32BitValue());
+                        }
+                    } else {
+                        HWSensorsErrorLog("Failed to validate sensor \"%s\" for SMM temperature sensor index \"%d\"", key->getCStringNoCopy(), temperatureIndex->unsigned32BitValue());
+                    }
+                }
+            }
+        }
+    }
+
+    if (registered_sensors > 0)
+      HWSensorsInfoLog("%d sensor%s added", registered_sensors, registered_sensors > 1 ? "s" : "");
+        
+    // Register service
+    registerService();
+    
+    HWSensorsInfoLog("started");
+    
+    return true;
+}
+
+void SMMSensors::stop(IOService *provider)
+{
+    super::stop(provider);
+}
+
+void SMMSensors::free()
+{
+    super::free();
+}

--- a/SMMSensors/SMMSensors.cpp
+++ b/SMMSensors/SMMSensors.cpp
@@ -292,7 +292,7 @@ bool SMMSensors::start(IOService *provider)
         OSNumber* numberFanMultiplier = OSDynamicCast(OSNumber, configuration->getObject("FanMultiplier"));
         if (numberFanMultiplier) {
             fanMultiplier = numberFanMultiplier->unsigned32BitValue();
-            HWSensorsInfoLog("Tachometer fan multiplier \"%d\"", fanMultiplier);
+            HWSensorsDebugLog("Tachometer fan multiplier \"%d\"", fanMultiplier);
         }
 
         /* Add platform configured fans */
@@ -326,14 +326,9 @@ bool SMMSensors::start(IOService *provider)
 
                         if (sensor != NULL) {
                             registered_sensors++;
-                            HWSensorsInfoLog("Registered tachometer sensor \"%s\" for SMM fan index \"%d\", type \"%s\".", key->getCStringNoCopy(), tachometerIndex->unsigned32BitValue(), getFanTypeName(fanType));
-                            
-                            this->keyStore->updateFanCounterKey();
-                            UInt8* fanCount = (UInt8 *)this->keyStore->getKey(KEY_FAN_NUMBER)->getValue();
-                            
-                            HWSensorsInfoLog("Fancount: %d", *fanCount);
+                            HWSensorsDebugLog("Registered tachometer sensor \"%s\" for SMM fan index \"%d\", type \"%s\".", key->getCStringNoCopy(), tachometerIndex->unsigned32BitValue(), getFanTypeName(fanType));
                         } else {
-                            HWSensorsInfoLog("Failed to register tachometer sensor \"%s\" for SMM fan index \"%d\"", key->getCStringNoCopy(), tachometerIndex->unsigned32BitValue());
+                            HWSensorsWarningLog("Failed to register tachometer sensor \"%s\" for SMM fan index \"%d\"", key->getCStringNoCopy(), tachometerIndex->unsigned32BitValue());
                         }
                     } else {
                         HWSensorsErrorLog("Failed to validate sensor \"%s\" for SMM fan index \"%d\"", key->getCStringNoCopy(), tachometerIndex->unsigned32BitValue());
@@ -374,9 +369,9 @@ bool SMMSensors::start(IOService *provider)
                         
                         if (sensor != NULL) {
                             registered_sensors++;
-                            HWSensorsInfoLog("Registered temperature sensor \"%s\" for SMM temperature sensor index \"%d\", type \"%s\".", key->getCStringNoCopy(), temperatureIndex->unsigned32BitValue(), getTempTypeName(tempType));
+                            HWSensorsDebugLog("Registered temperature sensor \"%s\" for SMM temperature sensor index \"%d\", type \"%s\".", key->getCStringNoCopy(), temperatureIndex->unsigned32BitValue(), getTempTypeName(tempType));
                         } else {
-                            HWSensorsInfoLog("Failed to register tachometer sensor \"%s\" for SMM temperature sensor index \"%d\"", key->getCStringNoCopy(), temperatureIndex->unsigned32BitValue());
+                            HWSensorsWarningLog("Failed to register tachometer sensor \"%s\" for SMM temperature sensor index \"%d\"", key->getCStringNoCopy(), temperatureIndex->unsigned32BitValue());
                         }
                     } else {
                         HWSensorsErrorLog("Failed to validate sensor \"%s\" for SMM temperature sensor index \"%d\"", key->getCStringNoCopy(), temperatureIndex->unsigned32BitValue());

--- a/SMMSensors/SMMSensors.h
+++ b/SMMSensors/SMMSensors.h
@@ -1,0 +1,63 @@
+//
+//  SMMSensors.h
+//  HWSensors
+//
+//  Created by darkvoid on 25.07.18.
+//
+//  Based on Linux dell-smm-hwmon (https://github.com/torvalds/linux/blob/master/drivers/hwmon/dell-smm-hwmon.c)
+//
+//  The MIT License (MIT)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+//  and associated documentation files (the "Software"), to deal in the Software without restriction,
+//  including without limitation the rights to use, copy, modify, merge, publish, distribute,
+//  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all copies or
+//  substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+//  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include "FakeSMCPlugin.h"
+
+#include <IOKit/IOTimerEventSource.h>
+#include <IOKit/IOLib.h>
+
+class EXPORT SMMSensors : public FakeSMCPlugin
+{
+    OSDeclareDefaultStructors(SMMSensors)
+    
+private:
+    int                     fanTypes[5] = { INT_MIN, INT_MIN, INT_MIN, INT_MIN, INT_MIN }; // Cache fan types for performance
+    uint                    fanMultiplier; // Multiplier for fan speeds (if required by configuration)
+
+    int                     getFanStatus(int fan);
+    int                     getFanSpeed(int fan);
+    int                     getFanType(int fan);
+    int                     getFanNominalSpeed(int fan, int speed);
+    int                     setFan(int fan, int speed);
+    
+    int                     getTempType(int sensor);
+    int                     getTemp(int sensor);
+    
+    int                     getPowerStatus(void);
+    
+    bool                    getDellSignature();
+    
+    const char *            getFanTypeName(int fanType);
+    const char *            getTempTypeName(int sensorType);
+
+    int                     _getTemp(int sensor);
+protected:
+    virtual bool            willReadSensorValue(FakeSMCSensor *sensor, float *outValue);
+    
+public:
+    virtual bool            start(IOService *provider);
+    virtual void            stop(IOService* provider);
+    virtual void            free(void);
+};

--- a/SMMSensors/smm.h
+++ b/SMMSensors/smm.h
@@ -1,0 +1,105 @@
+//
+//  smm.h
+//  HWSensors
+//
+//  Created by darkvoid on 25.07.18.
+//
+//  Based on Linux dell-smm-hwmon (https://github.com/torvalds/linux/blob/master/drivers/hwmon/dell-smm-hwmon.c)
+//
+//  The MIT License (MIT)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+//  and associated documentation files (the "Software"), to deal in the Software without restriction,
+//  including without limitation the rights to use, copy, modify, merge, publish, distribute,
+//  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all copies or
+//  substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+//  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#ifndef smm_h
+#define smm_h
+
+// Dell SMM Commands
+enum
+{
+    kSMM_GET_FN_STATUS      = 0x0025,
+    kSMM_GET_POWER_STATUS   = 0x0069,
+    kSMM_SET_FAN            = 0x01a3,
+    kSMM_GET_FAN            = 0x00a3,
+    kSMM_GET_SPEED          = 0x02a3,
+    kSMM_GET_FAN_TYPE       = 0x03a3,
+    kSMM_GET_NOM_SPEED      = 0x04a3,
+    kSMM_GET_TOLERANCE      = 0x05a3,
+    kSMM_GET_TEMP           = 0x10a3,
+    kSMM_GET_TEMP_TYPE      = 0x11a3,
+    kSMM_GET_POWER_TYPE     = 0x22a3,
+    //kSMM_GET_POWER_STATUS   = 0x24a3,
+    kSMM_GET_DOCK_STATE     = 0x40a3,
+    kSMM_GET_DELL_SIG       = 0xfea3,
+    kSMM_GET_DELL_SIG_2     = 0xffa3
+};
+
+#define SMM_DELL_SIG_1      0x44454C4C // "DELL"
+#define SMM_DELL_SIG_2      0x44494147 // "DIAG"
+
+#define SMM_MAX_TEMP        127
+
+// kSMM_GET_FAN_TYPE result codes
+// Note dock fans have 0x10 set
+//  (type & 0x10) ? type &= 0x0F : type;
+enum
+{
+    kSMM_FAN_PROCESSOR,
+    kSMM_FAN_MOTHERBOARD,
+    kSMM_FAN_GPU,
+    kSMM_FAN_PSU,
+    kSMM_FAN_CHIPSET,
+    kSMM_FAN_OTHER
+};
+
+// kSMM_GET_TEMP_TYPE result codes
+enum
+{
+    kSMM_TEMP_CPU,
+    kSMM_TEMP_GPU,
+    kSMM_TEMP_MEMORY,
+    kSMM_TEMP_MISC,
+    kSMM_TEMP_AMBIENT,
+    kSMM_TEMP_OTHER
+};
+
+// kSMM_GET_FN_STATUS result codes
+enum
+{
+    kSMM_FN_NONE    = 0x00,
+    kSMM_FN_UP      = 0x01,
+    kSMM_FN_DOWN    = 0x02,
+    kSMM_FN_MUTE    = 0x04,
+    kSMM_FN_MASK    = 0x07,
+    kSMM_FN_SHIFT   = 0x08
+};
+
+// kSMM_GET_POWER result codes
+enum
+{
+    kSMM_POWER_AC      = 0x05,
+    kSMM_POWER_BATTERY = 0x01
+};
+
+struct smm_regs {
+    unsigned int eax;
+    unsigned int ebx __attribute__ ((packed));
+    unsigned int ecx __attribute__ ((packed));
+    unsigned int edx __attribute__ ((packed));
+    unsigned int esi __attribute__ ((packed));
+    unsigned int edi __attribute__ ((packed));
+};
+
+#endif /* smm_h */

--- a/Shared/HWSensorsVersion.pch
+++ b/Shared/HWSensorsVersion.pch
@@ -23,6 +23,7 @@
 #define CPUSENSORS_BUNDLE                   org.hwsensors.driver.CPUSensors
 #define LPCSENSORS_BUNDLE                   org.hwsensors.driver.LPCSensors
 #define GPUSENSORS_BUNDLE                   org.hwsensors.driver.GPUSensors
+#define SMMSENSORS_BUNDLE                   org.hwsensors.driver.SMMSensors
 
 #define FAKESMCKEYSTORE_COMPATIBLE          1429
 #define LPCSENSORS_COMPATIBLE               1429

--- a/Versioning And Distribution.xcodeproj/xcshareddata/xcschemes/Build Kexts.xcscheme
+++ b/Versioning And Distribution.xcodeproj/xcshareddata/xcschemes/Build Kexts.xcscheme
@@ -84,6 +84,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D452B91521075817008456D6"
+               BuildableName = "SMMSensors.kext"
+               BlueprintName = "SMMSensors"
+               ReferencedContainer = "container:HWSensors.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "1D05ABE313ED0DAD00EADBF6"
                BuildableName = "FakeSMC.kext"
                BlueprintName = "FakeSMC"

--- a/makefile
+++ b/makefile
@@ -56,6 +56,7 @@ install_all:
 	sudo cp -R Build/Products/Release/ACPISensors.kext $(INSTDIR)/FakeSMC_ACPISensors.kext
 	sudo cp -R Build/Products/Release/LPCSensors.kext $(INSTDIR)/FakeSMC_LPCSensors.kext
 	sudo cp -R Build/Products/Release/GPUSensors.kext $(INSTDIR)/FakeSMC_GPUSensors.kext
+	sudo cp -R Build/Products/Release/SMMSensors.kext $(INSTDIR)/FakeSMC_SMMSensors.kext
 	if [ "`which tag`" != "" ]; then sudo tag -a Blue $(INSTDIR)/FakeSMC*.kext; fi
 	sudo touch /System/Library/Extensions
 	sudo kextcache -update-volume /
@@ -68,6 +69,7 @@ install_debug_all:
 	sudo cp -R Build/Products/Debug/ACPISensors.kext $(INSTDIR)/FakeSMC_ACPISensors.kext
 	sudo cp -R Build/Products/Debug/LPCSensors.kext $(INSTDIR)/FakeSMC_LPCSensors.kext
 	sudo cp -R Build/Products/Debug/GPUSensors.kext $(INSTDIR)/FakeSMC_GPUSensors.kext
+	sudo cp -R Build/Products/Debug/SMMSensors.kext $(INSTDIR)/FakeSMC_SMMSensors.kext
 	if [ "`which tag`" != "" ]; then sudo tag -a Purple $(INSTDIR)/FakeSMC*.kext; fi
 	sudo touch /System/Library/Extensions
 	sudo kextcache -update-volume /
@@ -81,6 +83,7 @@ distribute:
 	cp -R ./Build/Products/Release/ACPISensors.kext ./Distribute/FakeSMC_ACPISensors.kext
 	cp -R ./Build/Products/Release/LPCSensors.kext ./Distribute/FakeSMC_LPCSensors.kext
 	cp -R ./Build/Products/Release/GPUSensors.kext ./Distribute/FakeSMC_GPUSensors.kext
+	cp -R ./Build/Products/Release/SMMSensors.kext ./Distribute/FakeSMC_SMMSensors.kext
 	cp -R ./Build/Products/Release/HWMonitor.app ./Distribute
 	find ./Distribute -path *.DS_Store -delete
 	find ./Distribute -path *.dSYM -exec echo rm -r {} \; >/tmp/org.kozlek.rm.dsym.sh


### PR DESCRIPTION
This pull request adds the FakeSMC_SMMSensors plugin.

SMMSensors is based on the Linux [dell-smm-hwmon](https://github.com/torvalds/linux/blob/master/drivers/hwmon/dell-smm-hwmon.c) driver.

It enables FakeSMC to monitor both tachometers (fans) and temperature sensors on Dell systems.

On modern Dell systems System Management Mode is the only way to obtain fan RPM data, temperature sensors are often additionally accessible through ACPI EC queries, but can also be configured through SMM.

Configuration options follow the FakeSMC standard and allow configuration by default or per platform as required.

Each defined SMMSensor can be separately enabled/disabled as required.