### PR TITLE
Added NVMe controller support to HWMATASensor

### DIFF
--- a/HWMonitor.xcodeproj/project.pbxproj
+++ b/HWMonitor.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 		7EFE61B4183581090009BD0D /* HWMSmcSensor.m in Sources */ = {isa = PBXBuildFile; fileRef = 7EFE61B3183581090009BD0D /* HWMSmcSensor.m */; };
 		7EFE61B7183581090009BD0D /* HWMSensor.m in Sources */ = {isa = PBXBuildFile; fileRef = 7EFE61B6183581090009BD0D /* HWMSensor.m */; };
 		7EFF4395183649B20094860C /* HWMEngine.m in Sources */ = {isa = PBXBuildFile; fileRef = 7EFF4394183649B20094860C /* HWMEngine.m */; };
+		D4327F26210B868400CC5925 /* HWMNVMeSmartInterfaceWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = D4327F25210B868400CC5925 /* HWMNVMeSmartInterfaceWrapper.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -417,6 +418,9 @@
 		7EFF4393183649B20094860C /* HWMEngine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HWMEngine.h; sourceTree = "<group>"; };
 		7EFF4394183649B20094860C /* HWMEngine.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HWMEngine.m; sourceTree = "<group>"; };
 		A32FB4F217676DF300F27ADB /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		D41E4F7C210B52FD00C9C541 /* nvme.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = nvme.h; path = Shared/nvme.h; sourceTree = "<group>"; };
+		D4327F25210B868400CC5925 /* HWMNVMeSmartInterfaceWrapper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HWMNVMeSmartInterfaceWrapper.m; sourceTree = "<group>"; };
+		D4327F27210B869300CC5925 /* HWMNVMeSmartInterfaceWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HWMNVMeSmartInterfaceWrapper.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -612,6 +616,8 @@
 				7E56D2FA183FD96600D53B97 /* HWMSmcFanSensor.m */,
 				7E0E9F6F1EA31AF100667B92 /* HWMATASmartInterfaceWrapper.h */,
 				7E0E9F701EA31AF100667B92 /* HWMATASmartInterfaceWrapper.m */,
+				D4327F27210B869300CC5925 /* HWMNVMeSmartInterfaceWrapper.h */,
+				D4327F25210B868400CC5925 /* HWMNVMeSmartInterfaceWrapper.m */,
 				7EFE61AF183581090009BD0D /* HWMAtaSmartSensor.h */,
 				7EFE61B0183581090009BD0D /* HWMAtaSmartSensor.m */,
 				7EFE61AC183581090009BD0D /* HWMBatterySensor.h */,
@@ -721,6 +727,7 @@
 				7E3D41CC18B2B67A002F6559 /* ACPIProbeArgument.h */,
 				7E2678B7182523FE00B405DE /* smc.h */,
 				7EF393C1185C8D990033F1AB /* smc.c */,
+				D41E4F7C210B52FD00C9C541 /* nvme.h */,
 			);
 			name = Kernel;
 			sourceTree = "<group>";
@@ -1319,6 +1326,7 @@
 				7E6AEF6E18C9A4E800AD0CBC /* PopupAtaStateCell.m in Sources */,
 				7EFE61B4183581090009BD0D /* HWMSmcSensor.m in Sources */,
 				7E2EFB3F1B4F25C8004ABDC2 /* NSWindow+ULIZoomEffect.m in Sources */,
+				D4327F26210B868400CC5925 /* HWMNVMeSmartInterfaceWrapper.m in Sources */,
 				7EFF4395183649B20094860C /* HWMEngine.m in Sources */,
 				7EDA1A6D16D901100012A0DC /* PopupController.m in Sources */,
 				7EF393C2185C8D990033F1AB /* smc.c in Sources */,

--- a/HWMonitor/HWMNVMeSmartInterfaceWrapper.h
+++ b/HWMonitor/HWMNVMeSmartInterfaceWrapper.h
@@ -1,0 +1,66 @@
+//
+//  HWMNVMeSmartInterfaceWrapper.h
+//  HWMonitor
+//
+//  Created by darkvoid on 28/07/2018.
+//  Copyright © 2017 kozlek. All rights reserved.
+//
+
+// The parts of this code is based on http://smartmontools.sourceforge.net
+
+/*
+ * Home page of code is: http://smartmontools.sourceforge.net
+ *
+ * Copyright (C) 2002-10 Bruce Allen <smartmontools-support@lists.sourceforge.net>
+ * Copyright (C) 2008-10 Christian Franke <smartmontools-support@lists.sourceforge.net>
+ * Copyright (C) 1999-2000 Michael Cornwell <cornwell@acm.org>
+ * Copyright (C) 2000 Andre Hedrick <andre@linux-ide.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * You should have received a copy of the GNU General Public License
+ * (for example COPYING); if not, write to the Free
+ * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * This code was originally developed as a Senior Thesis by Michael Cornwell
+ * at the Concurrent Systems Laboratory (now part of the Storage Systems
+ * Research Center), Jack Baskin School of Engineering, University of
+ * California, Santa Cruz. http://ssrc.soe.ucsc.edu/
+ *
+ */
+
+#import <Foundation/Foundation.h>
+#include <IOKit/storage/ata/ATASMARTLib.h>
+
+#include "nvme.h"
+
+@interface HWMNVMeSmartInterfaceWrapper : NSObject
+{
+    NSArray *_attributes;
+    
+    NSDictionary *_overrides;
+    
+    NSString *_product;
+    NSString *_firmware;
+    NSString *_bsdName;
+    BOOL _rotational;
+}
+
+@property (nonatomic, assign) IOCFPlugInInterface** pluginInterface;
+@property (nonatomic, assign) IONVMeSMARTInterface** smartInterface;
+@property (nonatomic, strong) NSString * bsdName;
+@property (nonatomic, strong) NSString * product;
+@property (nonatomic, strong) NSString * firmware;
+@property (assign) BOOL isRotational;
+
+@property (readonly) NSArray * attributes;
+@property (readonly) NSDictionary * overrides;
+
++(HWMNVMeSmartInterfaceWrapper*)wrapperWithService:(io_service_t)service productName:(NSString*)productName firmware:(NSString*)firmware bsdName:(NSString*)bsdName isRotational:(BOOL)rotational;
++(HWMNVMeSmartInterfaceWrapper*)getWrapperForBsdName:(NSString*)name;
++(void)destroyAllWrappers;
+
+@end

--- a/HWMonitor/HWMNVMeSmartInterfaceWrapper.m
+++ b/HWMonitor/HWMNVMeSmartInterfaceWrapper.m
@@ -1,0 +1,301 @@
+//
+//  HWMNVMeSmartInterfaceWrapper.m
+//  HWMonitor
+//
+//  Created by Natan Zalkin on 16/04/2017.
+//  Copyright © 2017 kozlek. All rights reserved.
+//
+
+#import "HWMNVMeSmartInterfaceWrapper.h"
+#import "NSString+returnCodeDescription.h"
+
+#import "HWMSensor.h"
+#import "HWMEngine.h"
+#import "HWMConfiguration.h"
+
+#import "Localizer.h"
+
+#import <Growl/Growl.h>
+
+#pragma mark
+#pragma mark HWMNVMeSmartInterfaceWrapper
+
+#define RAW_TO_LONG(attribute)  (UInt64)attribute->rawvalue[0] | \
+(UInt64)attribute->rawvalue[1] << 8 | \
+(UInt64)attribute->rawvalue[2] << 16 | \
+(UInt64)attribute->rawvalue[3] << 24 | \
+(UInt64)attribute->rawvalue[4] << 32 | \
+(UInt64)attribute->rawvalue[5] << 40
+
+#define GetLocalizedAttributeName(key) \
+[[NSBundle mainBundle] localizedStringForKey:(key) value:@"" table:@"SmartAttributes"]
+
+static NSMutableDictionary *    gATASmartInterfaceWrapperCache = nil;
+static NSMutableDictionary *    gATASmartAttributeOverrideCache = nil;
+static NSArray *                gATASmartAttributeOverrideDatabase = nil;
+
+@implementation HWMNVMeSmartInterfaceWrapper
+
+@synthesize pluginInterface = _pluginInterface;
+@synthesize smartInterface = _smartInterface;
+@synthesize attributes = _attributes;
+@synthesize overrides = _overrides;
+
++(HWMNVMeSmartInterfaceWrapper*)wrapperWithService:(io_service_t)service productName:(NSString*)productName firmware:(NSString*)firmware bsdName:(NSString*)bsdName isRotational:(BOOL)rotational
+{
+    
+    if (!gATASmartInterfaceWrapperCache) {
+        gATASmartInterfaceWrapperCache = [[NSMutableDictionary alloc] init];
+    }
+    
+    HWMNVMeSmartInterfaceWrapper *wrapper = [gATASmartInterfaceWrapperCache objectForKey:bsdName];
+    
+    if (!wrapper) {
+        
+        IOCFPlugInInterface ** pluginInterface = NULL;
+        IONVMeSMARTInterface ** smartInterface = NULL;
+        SInt32 score = 0;
+        int tryCount = 4;
+        
+        do {
+            
+            IOReturn result;
+            
+            if (kIOReturnSuccess == (result = IOCreatePlugInInterfaceForService(service, kIONVMeSMARTUserClientTypeID, kIOCFPlugInInterfaceID, &pluginInterface, &score))) {
+                
+                HRESULT hresult;
+                
+                if (S_OK == (hresult = (*pluginInterface)->QueryInterface(pluginInterface, CFUUIDGetUUIDBytes(kIONVMeSMARTInterfaceID), (LPVOID)&smartInterface))) {
+                    
+                    wrapper = [[HWMNVMeSmartInterfaceWrapper alloc] init];
+                    
+                    (*smartInterface)->AddRef(smartInterface);
+                    (*pluginInterface)->AddRef(pluginInterface);
+                    
+                    wrapper.pluginInterface = pluginInterface;
+                    wrapper.smartInterface  = smartInterface;
+                    wrapper.bsdName = bsdName;
+                    wrapper.product = productName;
+                    wrapper.firmware = firmware;
+                    wrapper.isRotational = rotational;
+                    
+                    if ([wrapper readSMARTDataAndThresholds]) {
+                        [gATASmartInterfaceWrapperCache setObject:wrapper forKey:bsdName];
+                        return wrapper;
+                    }
+                }
+                else {
+                    NSLog(@"pluginInterface->QueryInterface error: %d for %@", hresult, productName);
+                }
+            }
+            else {
+                NSLog(@"IOCreatePlugInInterfaceForService error: %@ for %@", [NSString stringFromReturn:result], productName);
+            }
+            
+            if (smartInterface) {
+                (*smartInterface)->Release(smartInterface);
+            }
+            
+            if (pluginInterface) {
+                IODestroyPlugInInterface(pluginInterface);
+            }
+            
+            [NSThread sleepForTimeInterval:0.25];
+            
+        } while (--tryCount);
+        
+    }
+    
+    return wrapper;
+}
+
++(HWMNVMeSmartInterfaceWrapper*)getWrapperForBsdName:(NSString*)name
+{
+    if (name && gATASmartInterfaceWrapperCache) {
+        return [gATASmartInterfaceWrapperCache objectForKey:name];
+    }
+    
+    return nil;
+}
+
++(void)destroyAllWrappers
+{
+    [gATASmartInterfaceWrapperCache removeAllObjects];
+    
+    gATASmartInterfaceWrapperCache = nil;
+}
+
+-(BOOL)readSMARTDataAndThresholds
+{
+    NSLog(@"reading SMART data for %@", _product);
+    
+    IOReturn result = kIOReturnError;
+    
+    nvme_smart_log smartLog;
+    nvme_id_ctrl idControl;
+    
+    bzero(&smartLog, sizeof(smartLog));
+    //bzero(&idControl, sizeof(idControl));
+    
+    if (kIOReturnSuccess != (*_smartInterface)->SMARTReadData(_smartInterface, &smartLog)) {
+        NSLog(@"SMARTReadData returned error for: %@ code: %@", _product, [NSString stringFromReturn:result]);
+    }
+
+    if (kIOReturnSuccess != (*_smartInterface)->GetIdentifyData(_smartInterface, &idControl, 0)) {
+        NSLog(@"GetIdentifyData returned error for: %@ code: %@", _product, [NSString stringFromReturn:result]);
+    }
+
+    NSMutableArray * attributes = [[NSMutableArray alloc] init];
+    
+    NSNumber* spare_avail = [NSNumber numberWithUnsignedShort:smartLog.avail_spare];
+    NSNumber* spare_thres = [NSNumber numberWithUnsignedShort:smartLog.spare_thresh];
+    
+    [attributes addObject:@{@"level": [NSNumber numberWithInteger:spare_avail.longValue <= spare_thres.longValue ? kHWMSensorLevelExceeded : kHWMSensorLevelNormal],
+                            @"name": @kNVMeSMARTSAvailableSpareKey,
+                            @"title": @"SSD Available Spare",
+                            @"critical": @"Percent",
+                            @"value": spare_avail,
+                            @"worst": spare_avail,
+                            @"threshold": spare_thres,
+                            @"raw": spare_avail,
+                            @"rawFormatted": [NSString stringWithFormat:@"%@%%", spare_avail]
+                            }];
+
+    NSNumber* percent_remaining = [NSNumber numberWithUnsignedChar:100 - smartLog.percent_used];
+
+    [attributes addObject:@{@"level": [NSNumber numberWithInteger:percent_remaining.longValue > 0 ? kHWMSensorLevelNormal : kHWMSensorLevelExceeded],
+                            @"name": @kNVMeSMARTRemainingLifeKey,
+                            @"title": @"SSD Remaining Life",
+                            @"critical": @"Percent",
+                            @"value": percent_remaining,
+                            @"worst": percent_remaining,
+                            @"threshold": @0,
+                            @"raw": percent_remaining,
+                            @"rawFormatted": [NSString stringWithFormat:@"%@%%", percent_remaining],
+                            }];
+    
+    NSNumber* temperature = [NSNumber numberWithUnsignedShort:sg_get_unaligned_le16(smartLog.temperature) - 273];
+    NSNumber* temp_warn   = [NSNumber numberWithUnsignedShort:idControl.wctemp - 273];
+    //NSNumber* temp_crit   = [NSNumber numberWithUnsignedShort:idControl.cctemp - 273];
+    
+    [attributes addObject:@{@"level": [NSNumber numberWithInteger:temperature.longValue < temp_warn.longValue ? kHWMSensorLevelNormal : kHWMSensorLevelExceeded],
+                            @"name": @kNVMeSMARTTemperatureKey,
+                            @"title": @"SSD Temperature",
+                            @"critical": @"° Celcius",
+                            @"value": temperature,
+                            @"worst": temperature,
+                            @"threshold": temp_warn,
+                            @"raw": temperature,
+                            @"rawFormatted": [NSString stringWithFormat:@"%@°", temperature]
+                            }];
+
+    NSNumber* data_read = [NSNumber numberWithFloat:((sg_get_unaligned_le128(smartLog.data_units_read) * 512 * 1000) / 10000000000) / (float)100];
+    
+    [attributes addObject:@{@"level": [NSNumber numberWithInteger:kHWMSensorLevelDisabled],
+                            @"name": @kNVMESMARTDataReadKey,
+                            @"title": @"Data Read",
+                            @"critical": @"Tb",
+                            @"value": data_read,
+                            @"worst": data_read,
+                            @"threshold": @0,
+                            @"raw": data_read,
+                            @"rawFormatted": [NSString stringWithFormat:@"%@ Tb", data_read]
+                            }];
+
+    NSNumber* data_written = [NSNumber numberWithFloat:((sg_get_unaligned_le128(smartLog.data_units_written) * 512 * 1000) / 10000000000) / (float)100];
+    
+    [attributes addObject:@{@"level": [NSNumber numberWithInteger:kHWMSensorLevelDisabled],
+                            @"name": @kNVMeSMARTDataWrittenKey,
+                            @"title": @"Data Written",
+                            @"critical": @"Tb",
+                            @"value": data_written,
+                            @"worst": data_written,
+                            @"threshold": @0,
+                            @"raw": data_written,
+                            @"rawFormatted": [NSString stringWithFormat:@"%@ Tb", data_written]
+                            }];
+    
+    NSNumber* power_cycles = [NSNumber numberWithFloat:sg_get_unaligned_le128(smartLog.power_cycles)];
+    
+    [attributes addObject:@{@"level": [NSNumber numberWithInteger:kHWMSensorLevelDisabled],
+                            @"name": @kNVMeSMARTPowerCyclesKey,
+                            @"title": @"Power Cycles",
+                            @"value": power_cycles,
+                            @"worst": power_cycles,
+                            @"threshold": @0,
+                            @"raw": power_cycles,
+                            @"rawFormatted": power_cycles
+                            }];
+    
+    NSNumber* poweron_hours = [NSNumber numberWithFloat:sg_get_unaligned_le128(smartLog.power_on_hours)];
+    
+    [attributes addObject:@{@"level": [NSNumber numberWithInteger:kHWMSensorLevelDisabled],
+                            @"name": @kNVMeSMARTPowerOnHoursKey,
+                            @"title": @"Power-on Hours",
+                            @"value": poweron_hours,
+                            @"worst": poweron_hours,
+                            @"threshold": @0,
+                            @"raw": poweron_hours,
+                            @"rawFormatted": poweron_hours
+                            }];
+    
+    NSNumber* unsafe_shutdowns = [NSNumber numberWithFloat:sg_get_unaligned_le128(smartLog.unsafe_shutdowns)];
+    
+    [attributes addObject:@{@"level": [NSNumber numberWithInteger:kHWMSensorLevelDisabled],
+                            @"name": @kNVMeSMARTUnsafeShutdownsKey,
+                            @"title": @"Unsafe Shutdowns",
+                            @"value": unsafe_shutdowns,
+                            @"worst": unsafe_shutdowns,
+                            @"threshold": @0,
+                            @"raw": unsafe_shutdowns,
+                            @"rawFormatted": unsafe_shutdowns
+                            }];
+
+    NSNumber* media_errors = [NSNumber numberWithFloat:sg_get_unaligned_le128(smartLog.media_errors)];
+    
+    [attributes addObject:@{@"level": [NSNumber numberWithInteger:media_errors.longLongValue > 0 ? kHWMSensorLevelExceeded : kHWMSensorLevelNormal],
+                            @"name": @kNVMeSMARTIntegrityErrorsKey,
+                            @"title": @"Media Integrity Errors",
+                            @"value": media_errors,
+                            @"worst": media_errors,
+                            @"threshold": @0,
+                            @"raw": media_errors,
+                            @"rawFormatted": media_errors
+                            }];
+
+    NSNumber* num_err_log = [NSNumber numberWithFloat:sg_get_unaligned_le128(smartLog.num_err_log_entries)];
+    
+    [attributes addObject:@{@"level": [NSNumber numberWithInteger:num_err_log.longLongValue > 0 ? kHWMSensorLevelExceeded : kHWMSensorLevelNormal],
+                            @"name": @kNVMeSMARTErrorLogEntriesKey,
+                            @"title": @"Error Log Entries",
+                            @"value": num_err_log,
+                            @"worst": num_err_log,
+                            @"threshold": @0,
+                            @"raw": num_err_log,
+                            @"rawFormatted": num_err_log
+                            }];
+
+    _attributes = [attributes copy];
+
+    return result == kIOReturnSuccess;
+}
+
+-(void)releaseInterface
+{
+    if (_smartInterface) {
+        (*_smartInterface)->Release(_smartInterface);
+    }
+    
+    if (_pluginInterface) {
+        IODestroyPlugInInterface(_pluginInterface);
+    }
+}
+
+-(void)dealloc
+{
+    //NSLog(@"Wrapper deallocated for %@", _bsdName);
+    [self releaseInterface];
+}
+
+@end
+

--- a/Shared/nvme.h
+++ b/Shared/nvme.h
@@ -1,0 +1,241 @@
+//
+//  nvme.h
+//  HWMonitor
+//  Created by darkvoid on 28/07/2018.
+//
+//  Based on www.smartmontools.org/browser/
+//
+#ifndef nvme_h
+#define nvme_h
+
+#define kIONVMeSMARTUserClientTypeID        CFUUIDGetConstantUUIDWithBytes(NULL,                \
+                                            0xAA, 0x0F, 0xA6, 0xF9, 0xC2, 0xD6, 0x45, 0x7F,     \
+                                            0xB1, 0x0B, 0x59, 0xA1, 0x32, 0x53, 0x29, 0x2F)
+
+#define kIONVMeSMARTInterfaceID             CFUUIDGetConstantUUIDWithBytes(NULL,                \
+                                            0xCC, 0xD1, 0xDB, 0x19, 0xFD, 0x9A, 0x4D, 0xAF,     \
+                                            0xBF, 0x95, 0x12, 0x45, 0x4B, 0x23, 0x0A, 0xB6)
+
+#define kIOPropertyNVMeSMARTCapableKey      "NVMe SMART Capable"
+#define kIONVMeBlockStorageDevice           "IONVMeBlockStorageDevice"
+
+
+#define kNVMeSMARTTemperatureKey            "Temperature_Celsius"
+#define kNVMeSMARTRemainingLifeKey          "SSD_Life_Left"
+#define kNVMeSMARTSAvailableSpareKey        "NVMe_Available_Spare"
+#define kNVMESMARTDataReadKey               "NVMe_Data_Read"
+#define kNVMeSMARTDataWrittenKey            "NVMe_Data_Written"
+#define kNVMeSMARTPowerCyclesKey            "NVMe_Power_Cycles"
+#define kNVMeSMARTPowerOnHoursKey           "NVMe_PowerOn_Hours"
+#define kNVMeSMARTUnsafeShutdownsKey        "NVMe_Unsafe_Shutdowns"
+#define kNVMeSMARTIntegrityErrorsKey        "NVMe_Integrity_Errors"
+#define kNVMeSMARTErrorLogEntriesKey        "NVMe_Error_Log_Entries"
+
+typedef struct nvme_id_power_state {
+    unsigned short  max_power; // centiwatts
+    unsigned char   rsvd2;
+    unsigned char   flags;
+    unsigned int    entry_lat; // microseconds
+    unsigned int    exit_lat;  // microseconds
+    unsigned char   read_tput;
+    unsigned char   read_lat;
+    unsigned char   write_tput;
+    unsigned char   write_lat;
+    unsigned short  idle_power;
+    unsigned char   idle_scale;
+    unsigned char   rsvd19;
+    unsigned short  active_power;
+    unsigned char   active_work_scale;
+    unsigned char   rsvd23[9];
+} nvme_id_power_state;
+
+typedef struct nvme_id_ctrl {
+    unsigned short  vid;
+    unsigned short  ssvid;
+    char            sn[20];
+    char            mn[40];
+    char            fr[8];
+    unsigned char   rab;
+    unsigned char   ieee[3];
+    unsigned char   cmic;
+    unsigned char   mdts;
+    unsigned short  cntlid;
+    unsigned int    ver;
+    unsigned int    rtd3r;
+    unsigned int    rtd3e;
+    unsigned int    oaes;
+    unsigned int    ctratt;
+    unsigned char   rsvd100[156];
+    unsigned short  oacs;
+    unsigned char   acl;
+    unsigned char   aerl;
+    unsigned char   frmw;
+    unsigned char   lpa;
+    unsigned char   elpe;
+    unsigned char   npss;
+    unsigned char   avscc;
+    unsigned char   apsta;
+    unsigned short  wctemp;
+    unsigned short  cctemp;
+    unsigned short  mtfa;
+    unsigned int    hmpre;
+    unsigned int    hmmin;
+    unsigned char   tnvmcap[16];
+    unsigned char   unvmcap[16];
+    unsigned int    rpmbs;
+    unsigned short  edstt;
+    unsigned char   dsto;
+    unsigned char   fwug;
+    unsigned short  kas;
+    unsigned short  hctma;
+    unsigned short  mntmt;
+    unsigned short  mxtmt;
+    unsigned int    sanicap;
+    unsigned char   rsvd332[180];
+    unsigned char   sqes;
+    unsigned char   cqes;
+    unsigned short  maxcmd;
+    unsigned int    nn;
+    unsigned short  oncs;
+    unsigned short  fuses;
+    unsigned char   fna;
+    unsigned char   vwc;
+    unsigned short  awun;
+    unsigned short  awupf;
+    unsigned char   nvscc;
+    unsigned char   rsvd531;
+    unsigned short  acwu;
+    unsigned char   rsvd534[2];
+    unsigned int    sgls;
+    unsigned char   rsvd540[228];
+    char            subnqn[256];
+    unsigned char   rsvd1024[768];
+    unsigned int    ioccsz;
+    unsigned int    iorcsz;
+    unsigned short  icdoff;
+    unsigned char   ctrattr;
+    unsigned char   msdbd;
+    unsigned char   rsvd1804[244];
+    nvme_id_power_state  psd[32];
+    unsigned char   vs[1024];
+} nvme_id_ctrl;
+
+typedef struct nvme_smart_log {
+    UInt8  critical_warning;
+    UInt8  temperature[2];
+    UInt8  avail_spare;
+    UInt8  spare_thresh;
+    UInt8  percent_used;
+    UInt8  rsvd6[26];
+    UInt8  data_units_read[16];
+    UInt8  data_units_written[16];
+    UInt8  host_reads[16];
+    UInt8  host_writes[16];
+    UInt8  ctrl_busy_time[16];
+    UInt32 power_cycles[4];
+    UInt32 power_on_hours[4];
+    UInt32 unsafe_shutdowns[4];
+    UInt32 media_errors[4];
+    UInt32 num_err_log_entries[4];
+    UInt32 warning_temp_time;
+    UInt32 critical_comp_time;
+    UInt16 temp_sensor[8];
+    UInt32 thm_temp1_trans_count;
+    UInt32 thm_temp2_trans_count;
+    UInt32 thm_temp1_total_time;
+    UInt32 thm_temp2_total_time;
+    UInt8  rsvd232[280];
+} nvme_smart_log;
+
+// interface structure, obtained using lldb, could be incomplete or wrong
+typedef struct IONVMeSMARTInterface
+{
+    IUNKNOWN_C_GUTS;
+    
+    UInt16 version;
+    UInt16 revision;
+    
+    // NVMe smart data, returns nvme_smart_log structure
+    IOReturn ( *SMARTReadData )( void *  interface,
+                                struct nvme_smart_log * NVMeSMARTData );
+    
+    // NVMe IdentifyData, returns nvme_id_ctrl per namespace
+    IOReturn ( *GetIdentifyData )( void *  interface,
+                                  struct nvme_id_ctrl * NVMeIdentifyControllerStruct,
+                                  unsigned int ns );
+    
+    // Always getting kIOReturnDeviceError
+    IOReturn ( *GetFieldCounters )( void *   interface,
+                                   char * FieldCounters );
+    // Returns 0
+    IOReturn ( *ScheduleBGRefresh )( void *   interface);
+    
+    // Always returns kIOReturnDeviceError, probably expects pointer to some
+    // structure as an argument
+    IOReturn ( *GetLogPage )( void *  interface, void * data, unsigned int, unsigned int);
+    
+    /* GetSystemCounters Looks like a table with an attributes. Sample result:
+     
+     0x101022200: 0x01 0x00 0x08 0x00 0x00 0x00 0x00 0x00
+     0x101022208: 0x00 0x00 0x00 0x00 0x02 0x00 0x08 0x00
+     0x101022210: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+     0x101022218: 0x03 0x00 0x08 0x00 0xf1 0x74 0x26 0x01
+     0x101022220: 0x00 0x00 0x00 0x00 0x04 0x00 0x08 0x00
+     0x101022228: 0x0a 0x91 0xb1 0x00 0x00 0x00 0x00 0x00
+     0x101022230: 0x05 0x00 0x08 0x00 0x24 0x9f 0xfe 0x02
+     0x101022238: 0x00 0x00 0x00 0x00 0x06 0x00 0x08 0x00
+     0x101022240: 0x9b 0x42 0x38 0x02 0x00 0x00 0x00 0x00
+     0x101022248: 0x07 0x00 0x08 0x00 0xdd 0x08 0x00 0x00
+     0x101022250: 0x00 0x00 0x00 0x00 0x08 0x00 0x08 0x00
+     0x101022258: 0x07 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+     0x101022260: 0x09 0x00 0x08 0x00 0x00 0x00 0x00 0x00
+     0x101022268: 0x00 0x00 0x00 0x00 0x0a 0x00 0x04 0x00
+     .........
+     0x101022488: 0x74 0x00 0x08 0x00 0x00 0x00 0x00 0x00
+     0x101022490: 0x00 0x00 0x00 0x00 0x75 0x00 0x40 0x02
+     0x101022498: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+     */
+    IOReturn ( *GetSystemCounters )( void *  interface, char *, unsigned int *);
+    
+    
+    /* GetAlgorithmCounters returns mostly 0
+     0x102004000: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+     0x102004008: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+     0x102004010: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+     0x102004018: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+     0x102004020: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+     0x102004028: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+     0x102004038: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+     0x102004040: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+     0x102004048: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+     0x102004050: 0x00 0x00 0x00 0x00 0x80 0x00 0x00 0x00
+     0x102004058: 0x80 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+     0x102004060: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+     0x102004068: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+     0x102004070: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+     0x102004078: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+     0x102004080: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+     0x102004088: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+     0x102004090: 0x00 0x01 0x00 0x00 0x00 0x00 0x00 0x00
+     0x102004098: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+     
+     */
+    IOReturn ( *GetAlgorithmCounters )( void *  interface, char *, unsigned int *);
+} IONVMeSMARTInterface;
+
+
+static inline uint16_t sg_get_unaligned_le16(const void *p)
+{
+    uint16_t u;
+    memcpy(&u, p, 2);
+    return u;
+}
+
+static inline __uint128_t sg_get_unaligned_le128(const void *p)
+{
+    __uint128_t u;
+    memcpy(&u, p, 16);
+    return u;
+}
+
+#endif /* nvme_h */


### PR DESCRIPTION
This enhances HWMonitor with NVMe Controller SMART support.

NVMe controllers do not define SMART attributes in the same way ATA controllers do.
However the included approach fits into HWMonitor without too many changes.

Ideally the ATA monitoring part would have to be refactored for a 100% clean implementation, but I don't think its worth the effort at this point.

NVMe sensors in action display as follows:

![HWMonitor NVMe example](https://i.imgur.com/zMCxFzn.jpg)
