### PR TITLE
Localisation: - fixed typo in german resource file (wrong format string for formatting the fan rpm)

### DIFF
--- a/HWMonitor/de.lproj/Localizable.strings
+++ b/HWMonitor/de.lproj/Localizable.strings
@@ -135,7 +135,7 @@
 "An error occured while trying to download HWSensors installer!" = "Beim Herunterladen ist ein Fehler aufgetreten!";
 
 "%1.0f rpm" = "%1.0f U/min";
-"%1.0frpm" = "%1.0U/min";
+"%1.0frpm" = "%1.0fU/min";
 
 "Downloading %@" = "Lade %@ herunter";
 "%1.2f Mbytes" = "%1.2f MBytes";


### PR DESCRIPTION
fix for https://www.tonymacx86.com/threads/current-hwmonitor-app-showing-wrong-fan-rpm-in-system-menu-bar.262399/#post-1828759 and issue https://github.com/RehabMan/HP-ProBook-4x30s-DSDT-Patch/issues/15